### PR TITLE
quick fix to ::FixtureCommand::PopulateMore

### DIFF
--- a/lib/Test/DBIx/Class/FixtureCommand/PopulateMore.pm
+++ b/lib/Test/DBIx/Class/FixtureCommand/PopulateMore.pm
@@ -43,7 +43,7 @@ package Test::DBIx::Class::FixtureCommand::PopulateMore; {
 				definitions=>[@definitions],
 				schema=>$self->schema_manager->schema,
 				exception_cb=>sub {
-					$self->croak(@_);
+					$builder->croak(@_);
 				},
 			);
 		}; if ($@) {


### PR DESCRIPTION
My tests were dying with a stupid "can't locate object method "croak"' error. This should fix it.
