### PR TITLE
added a hint

### DIFF
--- a/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm
+++ b/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm
@@ -201,9 +201,16 @@ mostly harmless warnings, similar to:
 	drop cascades to constraint cd_artist_fk_cd_id_fkey on table cd_artist
 	NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "cd_pkey" for table "cd"
 
-In general these are harmless and can be ignored.  I will work with the author
-of L<Test::postgresql> to see if we can find a way to redirect these to a log 
-file somewhere.
+In general these are harmless and can be ignored.
+
+If you like to avoid these messages, you could change your connect_info like this:
+
+    connect_info => {
+        dsn => 'dbi:Pg:dbname=dbname', 
+        user => 'user', 
+        pass => 'secret',
+        on_connect_do => 'SET client_min_messages=WARNING;',
+    },
 
 =head1 AUTHOR
 


### PR DESCRIPTION
John, I found out how to avoid "noisy messages" during DB-creation in PostgreSQL databases and added a hint at the end of Test::DBIx::Class::SchemaManager::Trait::Testpostgresql. I hope my english isn't too bad...

The explanation for the setting can be found here:
http://markmail.org/message/e4cbkqntv6r7unm6
