### PR TITLE
add 'deploy_db' option

### DIFF
--- a/lib/Test/DBIx/Class.pm
+++ b/lib/Test/DBIx/Class.pm
@@ -1098,6 +1098,12 @@ set the previously mentioned option 'force_drop_table' to true as well, or we
 will attempt to create tables and populate them when they are already populated
 and created.
 
+=item deploy_db
+
+By default a fresh version of the schema is deployed when 'Test::DBIx::Class'
+is invoked.  If you want to skip the schema deployment and instead connect
+to an already existing and populated database, set this option to false.
+
 =item traits
 
 Traits are L<Moose::Role>s that are applied to the class managing the connection

--- a/t/13-test-sqlite.t
+++ b/t/13-test-sqlite.t
@@ -30,7 +30,13 @@ use File::Temp qw(tempdir);
     ok -f $dbname, 'SQLite DB was created'; 
   }
 
+  ok my $schema_manager =
+    Test::DBIx::Class->_initialize_schema(build_config($dbname, 1, 1)),
+            'Initialize schema with deploy_db => 0';
+
+
   ok -f $dbname, 'SQLite DB was kept, respecting to keep_db';
+
 
   unlink $dbname;
 }
@@ -55,12 +61,13 @@ done_testing;
 exit;
 
 sub build_config {
-  my ($dbname, $keep) = @_;
+  my ($dbname, $keep, $do_not_deploy) = @_;
   return {
     schema_class     => 'Test::DBIx::Class::Example::Schema',
     connect_info     => ["dbi:SQLite:dbname=$dbname",'',''],
     fixture_class    => '::Populate',
     keep_db          => $keep,
+    deploy_db        => !$do_not_deploy,
   };
 }
 


### PR DESCRIPTION
Hi! Me again. :-)

'deploy_db' is meant to be the flip-side of 'keep_db'. I.e., cause T::D::C not to deploy the schema at the beginning, for the instances where the user want to work on a database that is already existing.
