### PR TITLE
Hide diag

### DIFF
--- a/lib/Test/DBIx/Class/SchemaManager.pm
+++ b/lib/Test/DBIx/Class/SchemaManager.pm
@@ -17,17 +17,12 @@ has 'force_drop_table' => (
     default=>0,
 );
 
-has [qw/keep_db debug/] => (
+has [qw/keep_db tdbic_debug/] => (
     traits=>['ENV'],
     is=>'ro',
     isa=>'Bool',
     required=>1,
     default=>0,
-);
-
-has 'base_dir' => (
-    is=>'ro',
-    traits=>['ENV'],
 );
 
 has 'deploy_db' => (
@@ -227,7 +222,7 @@ sub install_fixtures {
         or (ref $args[0] eq 'HASH' && $args[0]->{command}) ) {
         my $arg = ref $args[0] ?  $args[0]->{command} : $args[0];
         my $fixture_class = to_FixtureClass($arg);
-        $self->builder->diag("Override default FixtureClass '".$self->fixture_class."' with $fixture_class") if $self->debug;
+        $self->builder->diag("Override default FixtureClass '".$self->fixture_class."' with $fixture_class") if $self->tdbic_debug;
         $fixture_command = $fixture_class->new(schema_manager=>$self);
         shift(@args);
     }

--- a/lib/Test/DBIx/Class/SchemaManager/Trait/Testmysqld.pm
+++ b/lib/Test/DBIx/Class/SchemaManager/Trait/Testmysqld.pm
@@ -14,7 +14,7 @@ requires 'setup', 'cleanup';
 
 ## has '+force_drop_table' => (is=>'rw',default=>1);
 
-has [qw/mysql_install_db mysqld/] => (
+has [qw/base_dir mysql_install_db mysqld/] => (
     is=>'ro',
     traits=>['ENV'],
 );
@@ -184,7 +184,7 @@ around 'setup' => sub {
             my $deployed = $self->deploy_testdb(%config);
             my $replicant_base_dir = $deployed->base_dir;
 
-            if ($self->debug || ($self->keep_db && !$self->base_dir)){
+            if ($self->tdbic_debug || ($self->keep_db && !$self->base_dir)){
                 Test::More::diag(
                     "Starting replicant mysqld with: ".
                     $deployed->mysqld.
@@ -252,7 +252,7 @@ sub get_default_connect_info {
     my $deployed_db = shift(@_) || $self->test_db_manager;
     my $base_dir = $deployed_db->base_dir;
 
-    if ($self->debug || ($self->keep_db && !$self->base_dir)){
+    if ($self->tdbic_debug || ($self->keep_db && !$self->base_dir)){
         Test::More::diag(
             "Starting mysqld with: ".
             $deployed_db->mysqld.
@@ -421,9 +421,9 @@ that should be generated at the top of your test.  It will look similar to:
 	# Starting mysqld with: /usr/local/mysql/bin/mysqld --defaults-file=/tmp/KHKfJf0Yf6/etc/my.cnf --user=root
 
 If you have specified the base_dir to use, this output will not be displayed by
-default. You can force it's display by setting debug to true. eg.
+default. You can force it's display by setting tdbic_debug to true. eg.
 
-	DEBUG=1 BASE_DIR=t/tmp KEEP_DB=1 prove -lv t/my-mysql-test.t
+	TDBIC_DEBUG=1 BASE_DIR=t/tmp KEEP_DB=1 prove -lv t/my-mysql-test.t
 
 You can then start the database instance yourself with something like:
 

--- a/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm
+++ b/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm
@@ -14,7 +14,7 @@ package Test::DBIx::Class::SchemaManager::Trait::Testpostgresql; {
 	);
 
 
-	has [qw/initdb postmaster/] => (
+	has [qw/base_dir initdb postmaster/] => (
 		is=>'ro', 
 		traits=>['ENV'], 
 	);
@@ -50,7 +50,7 @@ package Test::DBIx::Class::SchemaManager::Trait::Testpostgresql; {
 		my ($self) = @_;
 		my $port = $self->postgresqlobj->port;
 
-        if ($self->debug || ($self->keep_db && !$self->base_dir)){
+        if ($self->tdbic_debug || ($self->keep_db && !$self->base_dir)){
             Test::More::diag(
                 "Starting postgresql with: ".
                 $self->postgresqlobj->postmaster.
@@ -160,9 +160,9 @@ that should be generated at the top of your test.  It will look similar to:
 	# DBI->connect('DBI:Pg:dbname=template1;port=15432','postgres',''])
 
 If you have specified the base_dir to use, this output will not be displayed by
-default. You can force it's display by setting debug to true. eg.
+default. You can force it's display by setting tdbic_debug to true. eg.
 
-    DEBUG=1 BASE_DIR=t/tmp KEEP_DB=1 prove -lv t/my-postgresql-test.t
+    TDBIC_DEBUG=1 BASE_DIR=t/tmp KEEP_DB=1 prove -lv t/my-postgresql-test.t
 
 You can then start the database instance yourself with something like:
 

--- a/t/14-hide-diag.t
+++ b/t/14-hide-diag.t
@@ -7,7 +7,7 @@ use Test::More; {
 
 	ok my $config = {
 		schema_class => 'Test::DBIx::Class::Example::Schema',
-        debug => 0,
+        tdbic_debug => 0,
 	}, 'Created Sample inline configuration';
 
 
@@ -45,9 +45,7 @@ use Test::More; {
 
         ok !$fh, 'no diag emitted';
 
-#warn "##$fh##";
-
-        $config->{debug} = 1;
+        $config->{tdbic_debug} = 1;
         ok $schema_manager = Test::DBIx::Class->_initialize_schema($config)
           => 'Connected and deployed a testable schema';
 

--- a/t/15-hide-diag-mysqld.t
+++ b/t/15-hide-diag-mysqld.t
@@ -17,9 +17,9 @@ use Test::More; {
 
 
     #-------------------
-    note('debug=1');
+    note('tdbic_debug=1');
 
-    $config->{debug} = 1;
+    $config->{tdbic_debug} = 1;
     $fh = '';
 
     my $manager = Test::DBIx::Class::SchemaManager->initialize_schema({
@@ -30,9 +30,9 @@ use Test::More; {
     cmp_ok $fh, '=~', '# Starting mysqld with:', 'diag emitted';
 
     #-------------------
-    note('debug=0');
+    note('tdbic_debug=0');
 
-    $config->{debug} = 0;
+    $config->{tdbic_debug} = 0;
     $fh = '';
 
     my $manager2 = Test::DBIx::Class::SchemaManager->initialize_schema({

--- a/t/16-hide-diag-postgres.t
+++ b/t/16-hide-diag-postgres.t
@@ -16,9 +16,9 @@ use Test::More; {
 	}, 'Created Sample inline configuration';
 
     #-------------------
-    note('debug=1');
+    note('tdbic_debug=1');
 
-    $config->{debug} = 1;
+    $config->{tdbic_debug} = 1;
     $fh = '';
 
     my $manager = Test::DBIx::Class::SchemaManager->initialize_schema({
@@ -29,9 +29,9 @@ use Test::More; {
     cmp_ok $fh, '=~', '# Starting postgresql with:', 'diag emitted';
 
     #-------------------
-    note('debug=0');
+    note('tdbic_debug=0');
 
-    $config->{debug} = 0;
+    $config->{tdbic_debug} = 0;
     $fh = '';
 
     my $manager2 = Test::DBIx::Class::SchemaManager->initialize_schema({


### PR DESCRIPTION
ok, that wasn't meant to take that long..

I left the env var as DEBUG so it's in-line with everything else. DEBUG=1 forces diag to be displayed otherwise the db startup diags are displayed if keep_db is true and base_dir has not been set. ie you said to keep the db but you won't know where it is if we do..

what do you think?

test results certainly look tidier.. 8)
