### PR TITLE
Fix hide diag tests

### DIFF
--- a/t/15-hide-diag-mysqld.t
+++ b/t/15-hide-diag-mysqld.t
@@ -1,3 +1,17 @@
+
+# testing options while respecting external ENV variables
+#
+# KEEP_DB=1
+#    keep all databases created
+# BASE_DIR=1
+#    use the specified base dir
+#    don't emit diag (we know where the databases are created)
+# KEEP_DB=1 && BASE_DIR=0
+#    emit diag (so we can see where databases are created)
+# KEEP_DB=0
+#    clean up all databases created
+#    don't emit diag (we don't need to know where the databases are created)
+
 use Test::More; {
 
 	use strict;
@@ -11,7 +25,21 @@ use Test::More; {
 
 	use File::Path qw!rmtree!;
 
-	require_ok 'Test::DBIx::Class';
+    use FindBin qw($Bin);
+
+    use lib "$Bin/lib";
+    use TDBICOptions;
+
+    my $env_keep_db = $ENV{KEEP_DB};
+    my $env_base_dir = $ENV{BASE_DIR};
+
+    #TDBICOptions::check_base_dir();
+
+    require_ok 'Test::DBIx::Class';
+
+    TDBICOptions::notify();
+
+    my $dirs_created = {};
 
     my $builder = Test::DBIx::Class->builder;
     my $fh;
@@ -20,6 +48,8 @@ use Test::More; {
 	ok my $config = {
 		schema_class => 'Test::DBIx::Class::Example::Schema',
         traits => [qw!Testmysqld!],
+        tdbic_debug => 0,
+        keep_db => $env_keep_db,
 	}, 'Created Sample inline configuration';
 
 
@@ -35,6 +65,10 @@ use Test::More; {
     });
 
     cmp_ok $fh, '=~', '# Starting mysqld with:', 'diag emitted';
+    print ("$fh\n") if $env_keep_db;
+
+    my $dir = dir_created($fh);
+    print "# ERROR: could not identify dir from diag:\n$fh\n" unless $dir;
 
     #-------------------
     note('tdbic_debug=0');
@@ -47,7 +81,14 @@ use Test::More; {
         builder => $builder,
     });
 
-    ok !$fh, 'no diag emitted';
+    if ($env_keep_db && !$env_base_dir){
+        ok $fh, 'diag emitted as KEEP_DB was true and BASE_DIR was not';
+        print ("$fh\n");
+        my $dir = dir_created($fh);
+        print "# ERROR: could not identify dir from diag:\n$fh\n" unless $dir;
+    } else{
+        ok !$fh, 'no diag emitted';
+    }
 
     #-------------------
     note('keep_db=1');
@@ -60,11 +101,25 @@ use Test::More; {
         builder => $builder,
     });
 
-    cmp_ok $fh, '=~', '# Starting mysqld with:', 'diag emitted';
+    if ($env_base_dir){
+        ok !$fh, 'no diag emitted as BASE_DIR was true';
+    } else {
+        cmp_ok ($fh, '=~', '# Starting mysqld with:', 'diag emitted') or diag $fh;
+        print ("$fh\n") if $env_keep_db;
+    }
 
-    my ($dir) = $fh =~ m!defaults\-file=(/tmp/\w+)/!;
-    rmtree($dir);
+    $dir = dir_created($fh);
+    print "# ERROR: could not identify dir from diag:\n$fh\n" unless $dir;
 
+    TDBICOptions::print_dirs_created($dirs_created);
 
 	done_testing();
+
+    sub dir_created{
+        my $diag = $_[0];
+        my $regex = qr!defaults\-file=(/tmp/\w+)/!;
+        return TDBICOptions::dir_created($dirs_created, $regex, $diag);
+    }
+
 }
+

--- a/t/16-hide-diag-postgres.t
+++ b/t/16-hide-diag-postgres.t
@@ -1,3 +1,17 @@
+
+# testing options while respecting external ENV variables
+#
+# KEEP_DB=1
+#    keep all databases created
+# BASE_DIR=1
+#    use the specified base dir
+#    don't emit diag (we know where the databases are created)
+# KEEP_DB=1 && BASE_DIR=0
+#    emit diag (so we can see where databases are created)
+# KEEP_DB=0
+#    clean up all databases created
+#    don't emit diag (we don't need to know where the databases are created)
+
 use Test::More; {
 
 	use strict;
@@ -11,7 +25,21 @@ use Test::More; {
 
 	use File::Path qw!rmtree!;
 
+    use FindBin qw($Bin);
+
+    use lib "$Bin/lib";
+    use TDBICOptions;
+
+    my $env_keep_db = $ENV{KEEP_DB};
+    my $env_base_dir = $ENV{BASE_DIR};
+
+    #TDBICOptions::check_base_dir();
+
 	require_ok 'Test::DBIx::Class';
+
+    TDBICOptions::notify();
+
+    my $dirs_created = {};
 
     my $builder = Test::DBIx::Class->builder;
     my $fh;
@@ -20,6 +48,8 @@ use Test::More; {
 	ok my $config = {
 		schema_class => 'Test::DBIx::Class::Example::Schema',
         traits => [qw!Testpostgresql!],
+        tdbic_debug => 0,
+        keep_db => $env_keep_db,
 	}, 'Created Sample inline configuration';
 
     #-------------------
@@ -33,7 +63,13 @@ use Test::More; {
         builder => $builder,
     });
 
+    undef $manager;
+
     cmp_ok $fh, '=~', '# Starting postgresql with:', 'diag emitted';
+    print ("$fh\n") if $env_keep_db;
+
+    my $dir = dir_created($fh);
+    print "# ERROR: could not identify dir from diag:\n$fh\n" unless $dir;
 
     #-------------------
     note('tdbic_debug=0');
@@ -41,12 +77,21 @@ use Test::More; {
     $config->{tdbic_debug} = 0;
     $fh = '';
 
-    my $manager2 = Test::DBIx::Class::SchemaManager->initialize_schema({
+    $manager = Test::DBIx::Class::SchemaManager->initialize_schema({
         %$config, 
         builder => $builder,
     });
 
-    ok !$fh, 'no diag emitted';
+    undef $manager;
+
+    if ($env_keep_db && !$env_base_dir){
+        ok $fh, 'diag emitted as KEEP_DB was true and BASE_DIR was not';
+        print ("$fh\n");
+        my $dir = dir_created($fh);
+        print "# ERROR: could not identify dir from diag:\n$fh\n" unless $dir;
+    } else{
+        ok !$fh, 'no diag emitted';
+    }
 
     #-------------------
     note('keep_db=1');
@@ -54,16 +99,32 @@ use Test::More; {
     $config->{keep_db} = 1;
     $fh = '';
 
-    my $manager3 = Test::DBIx::Class::SchemaManager->initialize_schema({
+    $manager = Test::DBIx::Class::SchemaManager->initialize_schema({
         %$config, 
         builder => $builder,
     });
 
-    cmp_ok $fh, '=~', '# Starting postgresql with:', 'diag emitted';
+    undef $manager;
 
-    my ($dir) = $fh =~ m!\s\-D\s(/tmp/\w+)/data!;
-    rmtree($dir);
+    if ($env_base_dir){
+        ok !$fh, 'no diag emitted as BASE_DIR was true';
+    } else {
+        cmp_ok ($fh, '=~', '# Starting postgresql with:', 'diag emitted') or diag $fh;
+        print ("$fh\n") if $env_keep_db;
+    }
 
+    $dir = dir_created($fh);
+    print "# ERROR: could not identify dir from diag:\n$fh\n" unless $dir;
+
+    TDBICOptions::print_dirs_created($dirs_created);
 
 	done_testing();
+
+
+    sub dir_created{
+        my $diag = $_[0];
+        my $regex = qr!\s\-D\s(/tmp/\w+)/data!;
+        return TDBICOptions::dir_created($dirs_created, $regex, $diag);
+    }
+
 }

--- a/t/lib/TDBICOptions.pm
+++ b/t/lib/TDBICOptions.pm
@@ -1,0 +1,81 @@
+package TDBICOptions;
+
+use File::Path qw!rmtree!;
+
+my $keep_db = $ENV{KEEP_DB};
+my $base_dir = $ENV{BASE_DIR};
+
+sub notify{
+    if ($keep_db || $base_dir){
+        emit(
+            'This test is designed to exercise the keep_db and base_dir options of',
+            'the Test::DBIx::Class module. By setting either of these via enviroment',
+            'variables you are restricting the coverage of these tests. We will',
+            'adapt the tests as required to accommodate these settings.',
+            '',
+        );
+    }
+    if ($keep_db){
+        emit(
+            'keep_db is set to true. We will not delete any databases created by',
+            'these tests. We cannot test the automatic cleanup usually done when',
+            'keep_db is not true',
+            '',
+        );
+    }
+    if($base_dir){
+        emit(
+            'base_dir is set. We will create all databases in this directory. We',
+            'cannot test automatic tmp dir creation.',
+            '',
+        );
+    }
+}
+
+sub check_base_dir{
+    if (!$keep_db && $base_dir){
+        if (-d $base_dir){
+            opendir(my $dh, $base_dir) || die "can't opendir $base_dir: $!";
+            my @content = grep { !/^\.\.?$/ } readdir($dh);
+            die "\n\nWe will not use an existing directory with contents as base_dir without\nkeep_db set, otherwise we will delete existing contents"
+                if @content;
+            closedir $dh;
+        }
+    }
+}
+
+sub emit{
+    foreach(@_){
+        print "# $_\n";
+    }
+}
+
+sub print_dirs_created{
+    my ($dirs) = @_;
+    if($keep_db){
+        print "# tmp dirs created:\n";
+        foreach(keys %$dirs){
+            print "#\t$_\n";
+        }
+    }
+}
+
+sub dir_created{
+    my ($dirs_created, $regex, $diag) = @_;
+
+    if ($base_dir){
+        $dir = $base_dir;
+    } else {
+        ($dir) = $diag =~ $regex;
+    }
+
+    if (!$keep_db){
+      rmtree($dir) if $dir;
+    } else {
+        $dirs_created->{$dir} = 1;
+    }
+
+    return $dir;
+}
+
+1;


### PR DESCRIPTION
oh boy.. not sure that I haven't made a complete mess of this and done a lot of unnecessary work.. maybe I should have just said you can't run these tests with keep_db & base_dir.. 8)

hey, when I do a pull request, are you able to just pull it into a branch or do you have to pull it into master?
I should do a fork & pull request of my own to see how that works..

anyhoo.. as said in the commit message postgresql definitely has lots of issues when trying to use base_dir and parallel processing together.. I haven't looked into that.

---

```
FATAL:  lock file "postmaster.pid" already exists
```

these errors you saw have been fixed by destroying the SchemaManager object before creating another but posgresql still complains.. not sure if there's something else I need to be doing.. if there is, I can't see it.

```
(in cleanup) DBIx::Class::Storage::DBI::__ANON__(): DBI Exception: DBD::Pg::db do failed: ERROR:  cannot drop table job because other objects depend on it
DETAIL:  constraint company_employee_fk_job_id_fkey on table company_employee depends on table job
HINT:  Use DROP ... CASCADE to drop the dependent objects too. at /home/edoc/dev/apps/Test-DBIx-Class/lib/Test/DBIx/Class/SchemaManager.pm line 201
```
