### PR TITLE
Allow a pre-build/connected schema to be passed in

### DIFF
--- a/lib/Test/DBIx/Class/SchemaManager.pm
+++ b/lib/Test/DBIx/Class/SchemaManager.pm
@@ -49,7 +49,6 @@ has 'schema_class' => (
 
 has 'schema' => (
     is => 'ro',
-    init_arg => undef,
     lazy_build => 1,
 );
 


### PR DESCRIPTION
This allows me to use Dancer::Plugin::Schema's `schema` object and load fixtures into it
