### PR TITLE
Potential fix for issue 21

### DIFF
--- a/lib/Test/DBIx/Class.pm
+++ b/lib/Test/DBIx/Class.pm
@@ -1147,6 +1147,12 @@ and L<DBD::Pg> needs to be installed, but Postgresql does not need to be
 running, nor do you need to create a test database or user.  
 See L</TRAITS> for more.
 
+=item fail_on_schema_break
+
+Makes the test run fail when the schema can not be created.  Normally the
+test run is skipped when the schema fails to create.  A failure can be more
+convenient when you want to spot compilation failures.  
+
 =back
 
 Please note that although all initialization options can be set inlined or in


### PR DESCRIPTION
This looks like a reasonable fix to allow the tests to fail when there is a problem creating the schema.  I added the setting named fail_on_schema_break.  Does this look reasonable to you?  

```
 use Test::DBIx::Class {
   schema_class => 'OpusVL::TokenProcessor::DB::Schema',
   traits => [qw/Testpostgresql/],
   fail_on_schema_break => 1,
```

I was looking at the code relating to the environment variables and I couldn't quite figure out how that worked.  It looks like it probably ought to allow the overriding of the setting, but I couldn't quite figure out how.
