### PR TITLE
Add missing dependency on DateTime::Format::Pg

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,8 @@ requires 'File::Temp';
 requires 'File::Path';
 
 feature('MySql Support', -default => 0, 'Test::mysqld' => '0.14');
-feature('Postgresql Support', -default => 0, 'Test::postgresql' => '0.09');
+feature('Postgresql Support', -default => 0, 'Test::postgresql' => '0.09',
+        'DateTime::Format::Pg' => 0);
 
 test_requires 'Test::More' => '0.94';
 tests_recursive;


### PR DESCRIPTION
TDBIC fails t/09-test-postgresql.t if DateTime::Format::Pg is not installed, b/c TDBIC::Example::Schema requires it for the TimeStamp and InflateColumn::DateTime components. I guess it should technically be a test_requires, but I figure it's common enough to merit a regular dependency.  Thank you for your time and efforts and have a great New Year!

Cheers,
Fitz
