### PR TITLE
Add deploy_opts to SchemaManager

### DIFF
--- a/lib/Test/DBIx/Class.pm
+++ b/lib/Test/DBIx/Class.pm
@@ -1081,6 +1081,11 @@ Use this to customise connect_info if you have left that blank in order to
 have the dsn auto-generated, but require extra attributes such as name_sep
 and quote_char.
 
+=item deploy_opts
+
+Use this to customise any arguments that are to be passed to
+L<DBIx::Class::Schema/deploy>, such as add_drop_table or quote_identifiers.
+
 =item fixture_path
 
 These are a list of relative paths search for fixtures.  Each item should be

--- a/lib/Test/DBIx/Class/SchemaManager.pm
+++ b/lib/Test/DBIx/Class/SchemaManager.pm
@@ -64,6 +64,12 @@ has 'connect_opts' => (
     isa => 'HashRef',
 );
 
+has 'deploy_opts' => (
+    is => 'ro',
+    isa => 'HashRef',
+    default => sub { {} },
+);
+
 has 'connect_info_with_opts' => (
     is => 'ro',
     isa => 'HashRef',
@@ -188,10 +194,10 @@ sub _setup_debug {
 
 sub setup {
     my $self = shift @_;
-    my $deploy_args = $self->force_drop_table ? {add_drop_table => 1} : {};
+    my $deploy_opts = {%{$self->deploy_opts}, $self->force_drop_table ? (add_drop_table => 1) : ()};
     if(my $schema = $self->schema) {
         eval {
-            $schema->deploy($deploy_args);
+            $schema->deploy($deploy_opts);
         };if($@) {
             Test::More::fail("Error Deploying Schema: $@");
         }
@@ -272,7 +278,7 @@ Test::DBIx::Class::SchemaManager - Manages a DBIx::Class::SchemaManager for Test
 
 =head1 DESCRIPTION
 
-This class is a helper for L<Test::DBIx::Class>.  Basically it is a type of
+this class is a helper for L<Test::DBIx::Class>.  Basically it is a type of
 wrapper or adaptor for your schema so we can more easily and quickly deploy it
 and cleanup it for the purposes of automated testing.
 


### PR DESCRIPTION
This allows for optional twiddling of all SQLT parameters (ie quote_identifiers),
not just the explicitly provided drop_tables param.
