### PR TITLE
Fix link to DBIx::Class::ResultSource in README

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -45,7 +45,7 @@ assuming you put all of your test configuration in the standard place, your
     done_testing;
 
 Then, assuming the existence of a [DBIx::Class::Schema](https://metacpan.org/pod/DBIx::Class::Schema) subclass called,
-"MyApp::Schema" and some [DBIx::Class::ResultSources](https://metacpan.org/pod/DBIx::Class::ResultSources) named like "Person", 
+"MyApp::Schema" and some [DBIx::Class::ResultSource](https://metacpan.org/pod/DBIx::Class::ResultSource)s named like "Person", 
 "Person::Employee", "Job" and "Phone", will automatically deploy a testing 
 schema in the given database / storage (or auto deploy to an in-memory based
 [DBD::SQLite](https://metacpan.org/pod/DBD::SQLite) database), install fixtures and let you run some test cases, 


### PR DESCRIPTION
The README contains this link:

[DBIx::Class::ResultSources](https://metacpan.org/pod/DBIx::Class::ResultSources)

But as far as I can tell, there is no such thing as DBIx::Class::ResultSources. I'm guessing this is what was intended:

[DBIx::Class::ResultSource](https://metacpan.org/pod/DBIx::Class::ResultSource)s
