### PR TITLE
Exported subs return a new resultset every call

### DIFF
--- a/lib/Test/DBIx/Class.pm
+++ b/lib/Test/DBIx/Class.pm
@@ -316,7 +316,7 @@ sub import {
                             }
                             return $resultset->search(@search);
                         }
-                        return $resultset;
+                        return $resultset->search_rs;
                     }
                 };
             } $schema_manager->schema->sources,

--- a/t/17-importing-sources-gives-new-resultset.t
+++ b/t/17-importing-sources-gives-new-resultset.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::DBIx::Class 'Person';
+use Scalar::Util qw(refaddr);
+
+isnt(refaddr(Person()), refaddr(Person()), 'Got two different resultsets');
+done_testing();


### PR DESCRIPTION
Fixes the following bug found by mst:
https://rt.cpan.org/Public/Bug/Display.html?id=97844
