### PR TITLE
Switched Test::postgresql dependency to Test::PostgreSQL since Test::postgresql has gone away.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 This file documents the revision history for Perl extension Test-DBIx-Class.
 
+    - Replaced Test::Postgresql dependency with Test::PostgreSQL for those
+      wanting to test Postgres.
+
 0.42 13 Aug 2014
     - Fixed issue where a resultset isn't properly 'reset'
     - documentation improvements

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,7 +27,7 @@ requires 'File::Temp';
 requires 'File::Path';
 
 feature('MySql Support', -default => 0, 'Test::mysqld' => '0.14');
-feature('Postgresql Support', -default => 0, 'Test::postgresql' => '0.09',
+feature('Postgresql Support', -default => 0, 'Test::PostgreSQL' => '0.09',
         'DateTime::Format::Pg' => 0);
 
 test_requires 'Test::More' => '0.94';

--- a/README.mkdn
+++ b/README.mkdn
@@ -465,7 +465,7 @@ on your storage engine (such as SQLite or MySQL) you will have other options.
     needs to be installed, but MySQL does not need to be running, nor do you need
     to create a test database or user.   The third one is the 
     [Test::DBIx::Class::SchemaManager::Trait::Testpostgresql](https://metacpan.org/pod/Test::DBIx::Class::SchemaManager::Trait::Testpostgresql) trait, which is
-    built on top of [Test::postgresql](https://metacpan.org/pod/Test::postgresql) and allows you to deploy to and run tests
+    built on top of [Test::PostgreSQL](https://metacpan.org/pod/Test::PostgreSQL) and allows you to deploy to and run tests
     against a temporary instance of Postgresql.  For this trait Postgresql
     and [DBD::Pg](https://metacpan.org/pod/DBD::Pg) needs to be installed, but Postgresql does not need to be
     running, nor do you need to create a test database or user.  

--- a/lib/Test/DBIx/Class.pm
+++ b/lib/Test/DBIx/Class.pm
@@ -1146,7 +1146,7 @@ against a temporary instance of MySQL. For this trait MySQL and L<DBD::mysql>
 needs to be installed, but MySQL does not need to be running, nor do you need
 to create a test database or user.   The third one is the 
 L<Test::DBIx::Class::SchemaManager::Trait::Testpostgresql> trait, which is
-built on top of L<Test::postgresql> and allows you to deploy to and run tests
+built on top of L<Test::PostgreSQL> and allows you to deploy to and run tests
 against a temporary instance of Postgresql.  For this trait Postgresql
 and L<DBD::Pg> needs to be installed, but Postgresql does not need to be
 running, nor do you need to create a test database or user.  

--- a/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm
+++ b/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm
@@ -2,7 +2,7 @@ package Test::DBIx::Class::SchemaManager::Trait::Testpostgresql; {
 	
 	use Moose::Role;
 	use MooseX::Attribute::ENV;
-	use Test::postgresql;
+	use Test::PostgreSQL;
 	use Test::More ();
 	use Path::Class qw(dir);
 
@@ -26,8 +26,8 @@ package Test::DBIx::Class::SchemaManager::Trait::Testpostgresql; {
 		}
 
 		my %config = (
-			initdb_args => $Test::postgresql::Defaults{initdb_args} ."",
-			postmaster_args => $Test::postgresql::Defaults{postmaster_args},
+			initdb_args => $Test::PostgreSQL::Defaults{initdb_args} ."",
+			postmaster_args => $Test::PostgreSQL::Defaults{postmaster_args},
 		);
 
 		$config{base_dir} = $self->base_dir if $self->base_dir;	
@@ -39,10 +39,10 @@ package Test::DBIx::Class::SchemaManager::Trait::Testpostgresql; {
 			$self->force_drop_table(1);
 		}
 
-		if(my $testdb = Test::postgresql->new(%config)) {
+		if(my $testdb = Test::PostgreSQL->new(%config)) {
 			return $testdb;
 		} else {
-			die $Test::postgresql::errstr;
+			die $Test::PostgreSQL::errstr;
 		}
 	}
 
@@ -89,19 +89,19 @@ Test::DBIx::Class::SchemaManager::Trait::Testpostgresql - deploy to a test Postg
 
 =head1 DESCRIPTION
 
-This trait uses L<Test::postgresql> to auto create a test instance of Postgresql in a
+This trait uses L<Test::PostgreSQL> to auto create a test instance of Postgresql in a
 temporary area.  This way you can test against Postgresql without having to create
 a test database, users, etc.  Postgresql needs to be installed (but doesn't need to
 be running) as well as L<DBD::Pg>.  You need to install these yourself.
 
-Please review L<Test::postgresql> for help if you get stuck.
+Please review L<Test::PostgreSQL> for help if you get stuck.
 
 =head1 CONFIGURATION
 
 This trait supports all the existing features but adds some additional options
 you can put into your inlined of configuration files.  These following 
 additional configuration options basically map to the options supported by 
-L<Test::postgresql> and the docs are adapted shamelessly from that module.
+L<Test::PostgreSQL> and the docs are adapted shamelessly from that module.
 
 For the most part, if you have Postgresql installed in a normal, findable manner
 you should be able to leave all these options blank.
@@ -151,7 +151,7 @@ core functionality as described in the basic documentation.
 =head2 keep_db
 
 If you use the 'keep_db' option, this will preserve the temporarily created
-database files, however it will not prevent L<Test::postgresql> from stopping the
+database files, however it will not prevent L<Test::PostgreSQL> from stopping the
 database when you are finished.  This is a safety measure, since if we didn't
 stop a test generated database instance automatically, you could easily end up
 with many databases running at once, and that could bring your server or testing
@@ -206,7 +206,7 @@ document patches for how to do all the above on windows.
 
 =head2 Noisy warnings
 
-When running the L<Test::postgresql> instance, you'll probably see a lot of
+When running the L<Test::PostgreSQL> instance, you'll probably see a lot of
 mostly harmless warnings, similar to:
 
 	NOTICE:  drop cascades to 2 other objects

--- a/t/09-test-postgresql.t
+++ b/t/09-test-postgresql.t
@@ -9,8 +9,8 @@ use Test::More; {
 	use warnings;
 
 	BEGIN {
-		eval "use Test::postgresql"; if($@) {
-			plan skip_all => 'Test::postgresql not installed';
+		eval "use Test::PostgreSQL"; if($@) {
+			plan skip_all => 'Test::PostgreSQL not installed';
 		}
 	}
 

--- a/t/16-hide-diag-postgres.t
+++ b/t/16-hide-diag-postgres.t
@@ -18,8 +18,8 @@ use Test::More; {
 	use warnings;
 
 	BEGIN {
-		eval "use Test::postgresql"; if($@) {
-			plan skip_all => 'Test::postgresql not installed';
+		eval "use Test::PostgreSQL"; if($@) {
+			plan skip_all => 'Test::PostgreSQL not installed';
 		}
 	}
 


### PR DESCRIPTION
Test::postgresql has disappeared from CPAN but someone has put up a replacement module (with just a case change) that works as a drop in replacement.  I've just renamed the references to point to that new module.  The tests appear to still work on my box.
