### PR TITLE
Prevent test failure when Postgres not installed.

### DIFF
--- a/t/09-test-postgresql.t
+++ b/t/09-test-postgresql.t
@@ -12,6 +12,9 @@ use Test::More; {
 		eval "use Test::PostgreSQL"; if($@) {
 			plan skip_all => 'Test::PostgreSQL not installed';
 		}
+		eval "use DateTime::Format::Pg"; if($@) {
+			plan skip_all => 'DateTime::Format::Pg not installed';
+		}
 	}
 
 	my $lastname;

--- a/t/10-replication-mysql.t
+++ b/t/10-replication-mysql.t
@@ -12,6 +12,10 @@ BEGIN {
     eval "use Test::mysqld"; if($@) {
         plan skip_all => 'Test::mysqld not installed';
     }
+    eval "use MooseX::Types::LoadableClass 0.011 "; if($@) {
+        plan skip_all => 'The following modules are required for Replication MooseX::Types::LoadableClass >= 0.011 (see DBIx::Class::Optional::Dependencies for details)';
+    }
+
 }
 
 my $lastname;

--- a/t/16-hide-diag-postgres.t
+++ b/t/16-hide-diag-postgres.t
@@ -61,10 +61,22 @@ use Test::More; {
     $config->{tdbic_debug} = 1;
     $fh = '';
 
-    my $manager = Test::DBIx::Class::SchemaManager->initialize_schema({
-        %$config, 
-        builder => $builder,
-    });
+    my $manager;
+    eval {
+        $manager = Test::DBIx::Class::SchemaManager->initialize_schema({
+            %$config,
+            builder => $builder,
+        });
+    };
+    if ($@ or !$manager) {
+        Test::More::diag("Can't initialize a schema with the given configuration");
+        Test::More::diag("Returned Error: ".$@) if $@;
+        Test::More::diag(
+            Test::More::explain("configuration: " => $config)
+        );
+        done_testing;
+        exit;
+    }
 
     undef $manager;
 


### PR DESCRIPTION
This deals with the situation where you have Test::PostgreSQL
installed but not Postgres itself.

The error was, 

```
Use of uninitialized value $ENV{"USER"} in string eq at /opt/perl-5.20.2/lib/site_perl/5.20.2/Test/PostgreSQL.
pm line 63.
could not find initdb, please set appropriate PATH or POSTGRES_HOME at /root/.cpanm/work/1443460291.17572/Test
-DBIx-Class-0.43/blib/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm line 45.
Use of uninitialized value $ENV{"USER"} in string eq at /opt/perl-5.20.2/lib/site_perl/5.20.2/Test/PostgreSQL.
pm line 63.
        (in cleanup) could not find initdb, please set appropriate PATH or POSTGRES_HOME at /root/.cpanm/work/
1443460291.17572/Test-DBIx-Class-0.43/blib/lib/Test/DBIx/Class/SchemaManager/Trait/Testpostgresql.pm line 45.
t/16-hide-diag-postgres.t ..................... 
Dubious, test returned 2 (wstat 512, 0x200)
All 2 subtests passed 

Test Summary Report
-------------------
t/16-hide-diag-postgres.t                   (Wstat: 512 Tests: 2 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
```