### PR TITLE
drop_table_sql can't drop view

### DIFF
--- a/lib/Test/DBIx/Class/Example/Schema/Result/GermanPhone.pm
+++ b/lib/Test/DBIx/Class/Example/Schema/Result/GermanPhone.pm
@@ -1,16 +1,16 @@
 package Test::DBIx::Class::Example::Schema::Result::GermanPhone; {
 	use base 'Test::DBIx::Class::Example::Schema::Result';
 
-    __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+	__PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 	__PACKAGE__->table('german_phone');
 
-    __PACKAGE__->result_source_instance->is_virtual(1);
-    __PACKAGE__->result_source_instance->view_definition(
-        q{SELECT * FROM phone WHERE number LIKE '+49%'}
-    );
-    __PACKAGE__->result_source_instance->deploy_depends_on(
-        ['Test::DBIx::Class::Example::Schema::Result::Phone']
-    );
+	__PACKAGE__->result_source_instance->is_virtual(1);
+	__PACKAGE__->result_source_instance->view_definition(
+		q{SELECT * FROM phone WHERE number LIKE '+49%'}
+	);
+	__PACKAGE__->result_source_instance->deploy_depends_on(
+		['Test::DBIx::Class::Example::Schema::Result::Phone']
+	);
 
 	__PACKAGE__->add_columns(
 		fk_person_id => {

--- a/lib/Test/DBIx/Class/Example/Schema/Result/GermanPhone.pm
+++ b/lib/Test/DBIx/Class/Example/Schema/Result/GermanPhone.pm
@@ -1,0 +1,68 @@
+package Test::DBIx::Class::Example::Schema::Result::GermanPhone; {
+	use base 'Test::DBIx::Class::Example::Schema::Result';
+
+    __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+	__PACKAGE__->table('german_phone');
+
+    __PACKAGE__->result_source_instance->is_virtual(1);
+    __PACKAGE__->result_source_instance->view_definition(
+        q{SELECT * FROM phone WHERE number LIKE '+49%'}
+    );
+    __PACKAGE__->result_source_instance->deploy_depends_on(
+        ['Test::DBIx::Class::Example::Schema::Result::Phone']
+    );
+
+	__PACKAGE__->add_columns(
+		fk_person_id => {
+			data_type => 'varchar',
+			size => '36',
+			is_nullable => 0,
+		},
+		number => {
+			data_type => 'varchar',
+			size => '10',
+			is_nullable => 0,
+		},
+	);
+
+	__PACKAGE__->set_primary_key('fk_person_id','number');
+
+	__PACKAGE__->belongs_to(
+		owner => 'Test::DBIx::Class::Example::Schema::Result::Person',
+		{ 'foreign.person_id' => 'self.fk_person_id' },
+	);
+
+} 1
+
+__END__
+
+=head1 NAME
+
+Test::DBIx::Class::Example::Schema::Result::GermanPhone - Example of virtual view
+
+=head1 SYNOPSIS
+
+	TBD
+
+=head1 DESCRIPTION
+
+Sample result class for testing and for other component authors
+
+=head1 SEE ALSO
+
+The following modules or resources may be of interest.
+
+L<DBIx::Class>
+
+=head1 AUTHOR
+
+Vadim Pushtaev C<< <pushtaev@cpan.org> >>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2016, Vadim Pushtaev C<< <pushtaev@cpan.org> >>
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut

--- a/lib/Test/DBIx/Class/Example/Schema/Result/RussianPhone.pm
+++ b/lib/Test/DBIx/Class/Example/Schema/Result/RussianPhone.pm
@@ -1,0 +1,67 @@
+package Test::DBIx::Class::Example::Schema::Result::RussianPhone; {
+	use base 'Test::DBIx::Class::Example::Schema::Result';
+
+    __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+	__PACKAGE__->table('russian_phone');
+
+    __PACKAGE__->result_source_instance->view_definition(
+        q{SELECT * FROM phone WHERE number LIKE '+7%'}
+    );
+    __PACKAGE__->result_source_instance->deploy_depends_on(
+        ['Test::DBIx::Class::Example::Schema::Result::Phone']
+    );
+
+	__PACKAGE__->add_columns(
+		fk_person_id => {
+			data_type => 'varchar',
+			size => '36',
+			is_nullable => 0,
+		},
+		number => {
+			data_type => 'varchar',
+			size => '10',
+			is_nullable => 0,
+		},
+	);
+
+	__PACKAGE__->set_primary_key('fk_person_id','number');
+
+	__PACKAGE__->belongs_to(
+		owner => 'Test::DBIx::Class::Example::Schema::Result::Person',
+		{ 'foreign.person_id' => 'self.fk_person_id' },
+	);
+
+} 1
+
+__END__
+
+=head1 NAME
+
+Test::DBIx::Class::Example::Schema::Result::RussianPhone - Example of non-virtual view
+
+=head1 SYNOPSIS
+
+	TBD
+
+=head1 DESCRIPTION
+
+Sample result class for testing and for other component authors
+
+=head1 SEE ALSO
+
+The following modules or resources may be of interest.
+
+L<DBIx::Class>
+
+=head1 AUTHOR
+
+Vadim Pushtaev C<< <pushtaev@cpan.org> >>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2016, Vadim Pushtaev C<< <pushtaev@cpan.org> >>
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut

--- a/lib/Test/DBIx/Class/Example/Schema/Result/RussianPhone.pm
+++ b/lib/Test/DBIx/Class/Example/Schema/Result/RussianPhone.pm
@@ -1,15 +1,15 @@
 package Test::DBIx::Class::Example::Schema::Result::RussianPhone; {
 	use base 'Test::DBIx::Class::Example::Schema::Result';
 
-    __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+	__PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 	__PACKAGE__->table('russian_phone');
 
-    __PACKAGE__->result_source_instance->view_definition(
-        q{SELECT * FROM phone WHERE number LIKE '+7%'}
-    );
-    __PACKAGE__->result_source_instance->deploy_depends_on(
-        ['Test::DBIx::Class::Example::Schema::Result::Phone']
-    );
+	__PACKAGE__->result_source_instance->view_definition(
+		q{SELECT * FROM phone WHERE number LIKE '+7%'}
+	);
+	__PACKAGE__->result_source_instance->deploy_depends_on(
+		['Test::DBIx::Class::Example::Schema::Result::Phone']
+	);
 
 	__PACKAGE__->add_columns(
 		fk_person_id => {

--- a/t/02-initialize-schema.t
+++ b/t/02-initialize-schema.t
@@ -19,11 +19,13 @@ use Test::More; {
 			"CD::Track",
 			"Company",
 			"Company::Employee",
+			"GermanPhone",
 			"Job",
 			"Person",
 			"Person::Artist",
 			"Person::Employee",
 			"Phone",
+			"RussianPhone",
 		],
 		'Got expected sources';
 


### PR DESCRIPTION
_This issue is a copy of the original RT report: https://rt.cpan.org/Ticket/Display.html?id=112153_

This is the current implementation of `Test::DBIx::Class::SchemaManager::drop_table_sql` method:

```perl
sub drop_table_sql
{
    my $self = shift;
    my $table = shift;
    return "drop table $table";
}
```

The problem is, `$table` is not indeed a table, it can be a view. My current workaround is to use my own trait with the following `drop_table_sql` implementation:

```perl
sub drop_table_sql {
    my ($self, $table) = @_;

    my $schema = $self->schema;

    foreach my $source ($schema->sources) {
        my $source_info = $schema->source($source);
        if ($table eq $source_info->name) {
            return "DROP VIEW $table" if (ref $source_info) =~ /::View$/;
            last;
        }
    }

    return "DROP TABLE $table";
}
```

Could you please fix the original implementation (you can use with the better code than mine though).