### PR TITLE
Converted to Dist::Zilla.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+Test-DBIx-Class-*
+# Created by https://www.gitignore.io/api/perl,vim
+
+### Perl ###
+/blib/
+/.build/
+_build/
+cover_db/
+inc/
+Build
+!Build/
+Build.bat
+.last_cover_stats
+/Makefile
+/Makefile.old
+/MANIFEST.bak
+/META.yml
+/META.json
+/MYMETA.*
+nytprof.out
+/pm_to_blib
+*.o
+*.bs
+/_eumm/
+
+
+### Vim ###
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "maint"]
-	path = maint
-	url = git@github.com:jjn1056/Maker.git

--- a/cpanfile
+++ b/cpanfile
@@ -1,8 +1,3 @@
-#!/usr/bin/env perl
-
-use maint::Maker;
-
-all_from 'lib/Test/DBIx/Class.pm';
 requires 'Config::Any' => '0.19';
 requires 'DBIx::Class' => '0.08123';
 requires 'DBIx::Class::Schema::PopulateMore' => '0.16';
@@ -26,9 +21,14 @@ requires 'Test::Deep' => '0.106';
 requires 'File::Temp';
 requires 'File::Path';
 
-feature('MySql Support', -default => 0, 'Test::mysqld' => '0.14');
-feature('Postgresql Support', -default => 0, 'Test::PostgreSQL' => '0.09',
-        'DateTime::Format::Pg' => 0);
+feature 'mysql', 'MySql Support' => sub { 
+	requires 'Test::mysqld' => '0.14',
+};
+
+feature 'postgres', 'Postgresql Support' => sub { 
+	requires 'Test::PostgreSQL' => '0.09',
+	requires 'DateTime::Format::Pg' => '0',
+};
 
 test_requires 'Test::More' => '0.94';
-tests_recursive;
+

--- a/dist.ini
+++ b/dist.ini
@@ -1,0 +1,18 @@
+name    = Test-DBIx-Class
+author  = John Napiorkowski C<< <jjnapiork@cpan.org> >>
+license = Perl_5
+copyright_holder = John Napiorkowski
+copyright_year   = 2012
+
+; NOTE: one of the purposes of this config is to do as little
+; code writing magic as possible.
+
+[Prereqs::FromCPANfile]
+[@Starter]
+-remove = ReadmeAnyFromPod
+-remove = Test::Compile
+[VersionFromModule]
+
+[GitHub::Meta]
+
+


### PR DESCRIPTION
This does not do any file alteration.  Releases will require manual
version number increment and Changes file updates.

The cpanfile contains the dependency to allow someone to checkout
the module from git and install the dependencies without requiring
Dist::Zilla.

To do a release do dzil release.